### PR TITLE
chore(security): add passlib helper and README notes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 fastapi
 uvicorn
+
+# Security / hashing helper
+passlib

--- a/scripts/hash_password_example.py
+++ b/scripts/hash_password_example.py
@@ -1,0 +1,24 @@
+"""Small helper demonstrating hashing and verifying passwords with passlib.
+Run: python scripts/hash_password_example.py
+"""
+from passlib.context import CryptContext
+
+# Use pbkdf2_sha256 here to avoid platform-specific bcrypt C dependency issues
+pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    return pwd_context.verify(password, hashed)
+
+
+if __name__ == "__main__":
+    sample = "MyS3cretPassw0rd"
+    print("Sample password:", sample)
+    h = hash_password(sample)
+    print("Hashed:", h)
+    ok = verify_password(sample, h)
+    print("Verify result:", ok)

--- a/src/README.md
+++ b/src/README.md
@@ -12,7 +12,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r ../requirements.txt
    ```
 
 2. Run the application:
@@ -48,3 +48,13 @@ The application uses a simple data model with meaningful identifiers:
    - Grade level
 
 All data is stored in memory, which means data will be reset when the server restarts.
+
+## Security notes (starter)
+
+- This project is starting to collect more sensitive data and to support admin actions. Before adding any admin UI or persisting user credentials, follow these minimal security steps:
+   - Store passwords only as salted hashes (use `passlib[bcrypt]` or `argon2-cffi`). A small example helper is provided in `scripts/hash_password_example.py`.
+   - Validate incoming request payloads using Pydantic models to avoid malformed input.
+   - Prefer token-based auth (JWT) for APIs instead of cookie-based sessions to reduce CSRF surface area; if you use cookies, adopt proper CSRF protections.
+   - Avoid raw SQL string interpolation; use parameterized queries or an ORM (SQLAlchemy/SQLModel).
+
+These are starter notes — create a security checklist and complete the audit when moving beyond local development.


### PR DESCRIPTION
This PR adds a minimal security starter:

- adds `passlib` to `requirements.txt`
- adds `scripts/hash_password_example.py` demonstrating hashing and verification (uses pbkdf2_sha256 for compatibility)
- updates `src/README.md` with small security checklist and adjusted install instructions

This is a small, low-risk initial change to prepare for further work on password storage and auth. Please review and we can follow up with DB-backed user models and token auth next.